### PR TITLE
Update 04-use-a-container.md

### DIFF
--- a/Instructions/04-use-a-container.md
+++ b/Instructions/04-use-a-container.md
@@ -88,16 +88,16 @@ Many commonly used cognitive services APIs are available in container images. Fo
 
 1. In Visual Studio Code, in the **04-containers** folder, open **rest-test.cmd** and edit the **curl** command it contains (shown below), replacing *&lt;your_ACI_IP_address_or_FQDN&gt;* with the IP address or FQDN for your container.
 
-```
-curl -X POST "http://<your_ACI_IP_address_or_FQDN>:5000/text/analytics/v3.0/languages?" -H "Content-Type: application/json" --data-ascii "{'documents':[{'id':1,'text':'Hello world.'},{'id':2,'text':'Salut tout le monde.'}]}"
-```
+    ```
+    curl -X POST "http://<your_ACI_IP_address_or_FQDN>:5000/text/analytics/v3.0/languages?" -H "Content-Type: application/json" --data-ascii "{'documents':[{'id':1,'text':'Hello     world.'},{'id':2,'text':'Salut tout le monde.'}]}"
+    ```
 
 2. Save your changes to the script. Note that you do not need to specify the cognitive services endpoint or key - the request is processed by the containerized service. The container in turn communicates periodically with the service in Azure to report usage for billing, but does not send request data.
 3. Right-click the **04-containers** folder and open an integrated terminal. Then enter the following command to run the script:
 
-```
-rest-test
-```
+    ```
+    rest-test
+    ```
 
 4. Verify that the command returns a JSON document containing information about the language detected in the two input documents (which should be English and French).
 


### PR DESCRIPTION
Numbering was being disrupted due to no spaces being added in the commands to be executed.
