### PR TITLE
Check if sys.argv length is greater than 1.

### DIFF
--- a/15-computer-vision/Python/image-analysis/image-analysis.py
+++ b/15-computer-vision/Python/image-analysis/image-analysis.py
@@ -21,7 +21,7 @@ def main():
 
         # Get image
         image_file = 'images/street.jpg'
-        if len(sys.argv) > 0:
+        if len(sys.argv) > 1:
             image_file = sys.argv[1]
 
         # Authenticate Computer Vision client


### PR DESCRIPTION
# Module: 15
## Lab/Demo: 15-computer-vision

Fixes # .

Changes proposed in this pull request:

- check if `sys.argv` length is greater than 1 to assign image arg.
  - (argv[0] is always the name of the program that is executed.)