### PR TITLE
Fix typo in a sample Python script

### DIFF
--- a/Instructions/07-speech.md
+++ b/Instructions/07-speech.md
@@ -147,7 +147,7 @@ Now that you have a **SpeechConfig** for the speech service in your cognitive se
     # Configure speech recognition
     audio_config = speech_sdk.AudioConfig(use_default_microphone=True)
     speech_recognizer = speech_sdk.SpeechRecognizer(speech_config, audio_config)
-    print('Speak now...)
+    print('Speak now...')
     ```
 
 3. Now skip ahead to the **Add code to process the transcribed command** section below.


### PR DESCRIPTION
Added a missing quote 

# Module: 04
## Lab/Demo: Module 4 Labs (Speech)

Changes proposed in this pull request:

Add a missing single quote after "Speak now..."

```python
# Configure speech recognition
audio_config = speech_sdk.AudioConfig(use_default_microphone=True)
speech_recognizer = speech_sdk.SpeechRecognizer(speech_config, audio_config)
print('Speak now...)
```