### PR TITLE
Corrects C# code sample for DetectLanguage

### DIFF
--- a/Instructions/05-analyze-text.md
+++ b/Instructions/05-analyze-text.md
@@ -132,7 +132,7 @@ Now that you have created a client for the Text Analytics API, let's use it to d
     ```C
     // Get language
     DetectedLanguage detectedLanguage = CogClient.DetectLanguage(text);
-    Console.WriteLine($"\nLanguage: {detectedLanguage.Name}");
+    Console.WriteLine($"\nLanguage: {detectedLanguage.Value.Name}");
     ```
 
     **Python**


### PR DESCRIPTION
Access the detected language by `Value.Name` instead of just `Name`. 