### PR TITLE
Updated the instructions to prevent error

### DIFF
--- a/Instructions/13-bot-framework.md
+++ b/Instructions/13-bot-framework.md
@@ -227,7 +227,7 @@ az account set --subscription "<YOUR_SUBSCRIPTION_ID>"
 3. Enter the following command to create an application registration for **TimeBot** with the password **Super$ecretPassw0rd** (you can use an alternative display name and password if you wish, but make a note of them - you'll need them later).
 
 ```
-az ad app create --display-name "TimeBot" --password "Super$ecretPassw0rd" --available-to-other-tenants
+az ad app create --display-name "TimeBot" --password 'Super$ecretPassw0rd' --available-to-other-tenants
 ```
 
 4. When the command completes, a large JSON response is displayed. In this response, find the **appId** value and make a note of it. You will need it in the next procedure.


### PR DESCRIPTION
The secret would be better wrapped in single quotes to prevent any possible error, especially when using PowerShell window since the `$` will get recognised as part of a variable name

# Module: 7
## Lab/Demo: 13

Fixes # .

Changes proposed in this pull request:

- Add single quotes around the secret value since it contains `$`
-
-