### PR TITLE
Initiating Speech Config with Neural Voice

### DIFF
--- a/Instructions/07-speech.md
+++ b/Instructions/07-speech.md
@@ -281,6 +281,7 @@ Your speaking clock application accepts spoken input, but it doesn't actually sp
     
     ```C#
     // Configure speech synthesis
+    speechConfig.SpeechSynthesisVoiceName = "en-GB-RyanNeural";
     using SpeechSynthesizer speechSynthesizer = new SpeechSynthesizer(speechConfig);
     ```
     
@@ -288,6 +289,7 @@ Your speaking clock application accepts spoken input, but it doesn't actually sp
     
     ```Python
     # Configure speech synthesis
+    speech_config.speech_synthesis_voice_name = "en-GB-RyanNeural"
     speech_synthesizer = speech_sdk.SpeechSynthesizer(speech_config)
     ```
     


### PR DESCRIPTION
# Module: 4
## Lab/Demo: 7

Fixes #93 

Changes proposed in this pull request:

- Added an initiation for the speech SDK to use a Neural voice for both Python and C#.