### PR TITLE
Use Object ID to reference a service principal

### DIFF
--- a/Instructions/02-cognitive-services-security.md
+++ b/Instructions/02-cognitive-services-security.md
@@ -126,7 +126,7 @@ First, you need to create a key vault and add a *secret* for the cognitive servi
 
 ### Create a service principal
 
-To access the secret in the key vault, your application must use a service principal that has access to the secret. You'll use the Azure command line interface (CLI) to create the service principal and grant access to the secret in Azure Vault.
+To access the secret in the key vault, your application must use a service principal that has access to the secret. You'll use the Azure command line interface (CLI) to create the service principal, find its object ID, and grant access to the secret in Azure Vault.
 
 1. Return to Visual Studio Code, and in the integrated terminal for the **02-cognitive-security** folder, run the following Azure CLI command, replacing *&lt;spName&gt;* with a suitable name for an application identity (for example, *ai-app*). Also replace *&lt;subscriptionId&gt;* and *&lt;resourceGroup&gt;* with the correct values for your subscription ID and the resource group containing your cognitive services and key vault resources:
 
@@ -150,10 +150,16 @@ The output of this command includes information about your new service principal
 
 Make a note of the **appId**, **password**, and **tenant** values - you will need them later (if you close this terminal, you won't be able to retrieve the password; so it's important to note the values now - you can paste the output into a new text file in Visual Studio Code to ensure you can find the values you need later!)
 
-2. To assign permission for your new service principal to access secrets in your Key Vault, run the following Azure CLI command, replacing *&lt;keyVaultName&gt;* with the name of your Azure Key Vault resource and *&lt;spName&gt;* with the same value you provided when creating the service principal.
+2. To get the **object ID** of your service principal, run the following Azure CLI command, replacing *&lt;appId&gt;* with the value of your service principal's app ID.
 
     ```
-    az keyvault set-policy -n <keyVaultName> --spn "api://<spName>" --secret-permissions get list
+    az ad sp show --id <appId> --query objectId --out tsv
+    ```
+
+3. To assign permission for your new service principal to access secrets in your Key Vault, run the following Azure CLI command, replacing *&lt;keyVaultName&gt;* with the name of your Azure Key Vault resource and *&lt;objectId&gt;* with the value of your service principal's object ID.
+
+    ```
+    az keyvault set-policy -n <keyVaultName> --object-id <objectId> --secret-permissions get list
     ```
 
 ### Use the service principal in an application


### PR DESCRIPTION
# Module: 02
## Lab/Demo: 02

In Azure CLI version 2.29 and later, running the command "az keyvault set-policy" with the parameter --spn set to 
'api:&lt;spName&gt;', where &lt;spName&gt; is the name of the service principal, fails. It results in the error message "Unable to find user with spn ‘api:&lt;spName&gt;'. Unable to get object id from principal name."

This is due to the fact that the ‘name’ property of the service principal is deprecated. Setting --spn to the app ID works. However, this may not work with older versions of Azure CLI, including version 2.17.1, which is used in the hosted lab VM.

To make sure this lab’s instructions are valid for both the hosted lab’s VM and the current version of Azure CLI, the instructions are updated to:

- show how to find the object ID of the service principal using Azure CLI, and

- reference the service principal by its object ID, instead of its name, in the "az keyvault set-policy" command.