### PR TITLE
Fix type error that causes failed search queries

### DIFF
--- a/22-Create-a-search-solution/Python/margies-travel/templates/search.html
+++ b/22-Create-a-search-solution/Python/margies-travel/templates/search.html
@@ -36,7 +36,7 @@
         <li>Size: {{ search_result['metadata_storage_size'] }} bytes</li>
         <li>Modified: {{ search_result['metadata_storage_last_modified'] }}</li>
         <li>Language: {{ search_result['language'] }}</li>
-        <li>Sentiment: {% if search_result['sentiment'] >= 0.5 %} &#128578; {% else %} &#128577; {% endif %} {{ search_result['sentiment'] }}</li>
+        <li>Sentiment: {% if search_result['sentiment'] != None %} {% if search_result['sentiment'] >= 0.5 %} &#128578; {% else %} &#128577; {% endif %} {% endif %} {{ search_result['sentiment'] }}</li>
         <li>Key Phrases:</li>
             <ul class="resultAttributes">
                 {% for key_phrase in search_result['keyphrases'][:5]: %}


### PR DESCRIPTION
# Module: 12
## Lab/Demo: 22

Search queries using the Flask web app were failing with the error message:
"Opps! An error occurred. '>=' not supported between instances of 'NoneType'
and 'float'."

This is the result of comparing null instances of the sentiment score and the
float 0.5. The code is updated to avoid this.

Fixes issue #96 