### PR TITLE
Updating to navigate to Storage Browser v Explorer

### DIFF
--- a/Instructions/21-form-recognizer.md
+++ b/Instructions/21-form-recognizer.md
@@ -100,7 +100,7 @@ setup
 
 > **Important**: Before moving on, paste the SAS URI somewhere you will be able to retrieve it again later (for example, in a new text file in Visual Studio Code).
 
-15. In the Azure portal, refresh the resource group and verify that it contains the Azure Storage account just created. Open the storage account and in the pane on the left, select **Storage Explorer**. Then in Storage Explorer, expand **BLOB CONTAINERS** and select the **sampleforms** container to verify that the files have been uploaded from your local **21-custom-form/sample-forms** folder.
+15. In the Azure portal, refresh the resource group and verify that it contains the Azure Storage account just created. Open the storage account and in the pane on the left, select **Storage Browser (preview)**. Then in Storage Browser, expand **BLOB CONTAINERS** and select the **sampleforms** container to verify that the files have been uploaded from your local **21-custom-form/sample-forms** folder.
 
 ## Train a model *without* labels
 


### PR DESCRIPTION
# Module: 11

Fixes #100 .

Changes proposed in this pull request:

- The Azure Portal has updated to `Storage Browser` instead of `Storage Explorer` - updated to the new verbage.