### PR TITLE
Update - Prepare to use the Computer Vision SDK

### DIFF
--- a/Instructions/15-computer-vision.md
+++ b/Instructions/15-computer-vision.md
@@ -53,6 +53,8 @@ dotnet add package Microsoft.Azure.CognitiveServices.Vision.ComputerVision --ver
 
 ```
 pip install azure-cognitiveservices-vision-computervision==0.7.0
+pip install Pillow
+pip install matplotlib
 ```
     
 3. View the contents of the **image-analysis** folder, and note that it contains a file for configuration settings:


### PR DESCRIPTION
Section updated:
- Lab 15
- Prepare to use the Computer Vision SDK
- Step 2
- Python
	#Added:
	pip install Pillow
	pip install matplotlib

Error without previous commands:
"from PIL import Image, ImageDraw
ModuleNotFoundError: No module named 'PIL'
from matplotlib import pyplot as plt
ModuleNotFoundError: No module named 'matplotlib'"

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-