### PR TITLE
Copying review text files to bin dir

### DIFF
--- a/05-analyze-text/C-Sharp/text-analysis/text-analysis.csproj
+++ b/05-analyze-text/C-Sharp/text-analysis/text-analysis.csproj
@@ -9,9 +9,23 @@
     <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
   </ItemGroup>
-
-  <ItemGroup>
+<ItemGroup>
     <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="reviews\review1.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="reviews\review2.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="reviews\review3.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="reviews\review4.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="reviews\review5.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
Documentation does not state this has to be done manually. Either documentation should add a step to copy the review files or the code change could be added to the code base.

# Module: 05
## Lab/Demo: 01

Fixes # .

Changes proposed in this pull request:

- Copy reviews to ouput dir.