### PR TITLE
Fixed typo `Language` on 12-qna-maker.md

### DIFF
--- a/Instructions/12-qna-maker.md
+++ b/Instructions/12-qna-maker.md
@@ -161,4 +161,4 @@ Most commonly, the client applications used to retrieve answers from a knowledge
 
 ## More information
 
-To learn more about question answering in the Language service, see the [Langage service documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/language-service/question-answering/overview).
+To learn more about question answering in the Language service, see the [Language service documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/language-service/question-answering/overview).


### PR DESCRIPTION
from `Langage` to `Language`

# Module: 12
## Lab/Demo: 00

Fixes #139 

Changes proposed in this pull request:
fix typo on module 12
[#139](https://github.com/MicrosoftLearning/AI-102-AIEngineer/blob/master/Instructions/12-qna-maker.md)
-
-
-