### PR TITLE
Edited a typo on `20-ocr.md` under the `Instructions` folder

### DIFF
--- a/Instructions/20-ocr.md
+++ b/Instructions/20-ocr.md
@@ -200,7 +200,7 @@ python read-text.py
 6. When prompted, enter **1** and observe the output, which is the text extracted from the image.
 7. If desired, go back to the code you added to **GetTextRead** and find the comment in the nested `for` loop at the end, uncomment the last line, save the file, and rerun steps 5 and 6 above to see the bounding box of each line. Be sure to re-comment that line and save the file before moving on.
 
-## Use the Read API to read text from an document
+## Use the Read API to read text from a document
 
 1. In the code file for your application, in the **Main** function, examine the code that runs if the user selects menu option **2**. This code calls the **GetTextRead** function, passing the path to a PDF document file.
 2. In the **read-text/images** folder, right-click **Rome.pdf** and select **Reveal in File Explorer**. Then in File Explorer, open the PDF file to view it.


### PR DESCRIPTION
# Module: 20
## Lab/Demo: Instructions

Fixes # I edited a simple typo I noticed on `20-ocr.md` under the `Instructions` folder

Changes proposed in this pull request:

- Now `Use the Read API to read text from a document`.
- Used to be `Use the Read API to read text from an document` which is grammatically incorrect.
