### PR TITLE
Fixes to the instructions and Python code

### DIFF
--- a/Instructions/10b-language-understanding-client-(preview).md
+++ b/Instructions/10b-language-understanding-client-(preview).md
@@ -64,7 +64,7 @@ If you already have a **Clock** project from a previous lab or exercise, you can
 
     > **Note**: Because the deployment name **production** is hard-coded in the clock-client code (used later in the lab), capitalize and spell the name exactly as described. 
 
-8. The client applications needs the *endpoint URL* and *Primary key* to use your deployed model. To get those parameters, open the Azure portal at `https://portal.azure.com`, and sign in using the Microsoft account associated with your Azure subscription. On the Search bar, search for **Language** and select it to choose the *Cognitiive Services|Language service*.
+8. The client applications needs the *endpoint URL* and *Primary key* to use your deployed model. After the deployment is complete, to get those parameters, open the Azure portal at `https://portal.azure.com`, and sign in using the Microsoft account associated with your Azure subscription. On the Search bar, search for **Language** and select it to choose the *Cognitiive Services|Language service*.
 
 9. Your Language service resource should be listed, select that resource.
 

--- a/Instructions/10b-language-understanding-client-(preview).md
+++ b/Instructions/10b-language-understanding-client-(preview).md
@@ -64,7 +64,7 @@ If you already have a **Clock** project from a previous lab or exercise, you can
 
     > **Note**: Because the deployment name **production** is hard-coded in the clock-client code (used later in the lab), capitalize and spell the name exactly as described. 
 
-8. The client applications needs the *endpoint URL* and *Primary key* to use your deployed model. After the deployment is complete, to get those parameters, open the Azure portal at `https://portal.azure.com`, and sign in using the Microsoft account associated with your Azure subscription. On the Search bar, search for **Language** and select it to choose the *Cognitiive Services|Language service*.
+8. The client applications needs the **Endpoint URL** and **Primary key** to use your deployed model. After the deployment is complete, to get those parameters, open the Azure portal at [https://portal.azure.com](https://portal.azure.com/?azure-portal=true), and sign in using the Microsoft account associated with your Azure subscription. On the Search bar, search for **Language** and select it to choose the *Cognitive Services|Language service*.
 
 9. Your Language service resource should be listed, select that resource.
 


### PR DESCRIPTION
# Module: 5
## Lab/Demo: 10b

Fixes # .

Changes proposed in this pull request:

- Fixed the instructions to get the Key and endpoint from the Azure portal.
- Since for Python, the azure.ai.language.conversations.models library was merged into the azure.ai.language.conversations library, fixed the code to use the method analyze_conversation from the  ConversationAnalysisClient object instead of the old analyze_conversations method from the azure.ai.language.conversations.models library.  Additionally, this method now returns an array instead of an object, so fixed the code to use the array instead.
