### PR TITLE
LAB 02 - Add user to the access policy of the Key Vault

### DIFF
--- a/Instructions/02-cognitive-services-security.md
+++ b/Instructions/02-cognitive-services-security.md
@@ -112,6 +112,7 @@ First, you need to create a key vault and add a *secret* for the Azure AI servic
     
     - **Access configuration** tab
         -  **Permission model**: Vault access policy
+        - Scroll down to the **Access policies** section and select your user using the checkbox on the left.
      
 3. Wait for deployment to complete and then go to your key vault resource.
 4. In the left navigation pane, select **Secrets** (in the Objects section).


### PR DESCRIPTION
# Module: 02
## Lab/Demo: 02

Changes proposed in this pull request:
In the "Secure key access with Azure Key Vault" step, and in particular in the "Create a key vault" task, when you select Access Policy as permission model you need to scroll down and add your user to the policy, otherwise you cannot create the secret. 
