### PR TITLE
Module 21 - Update setup.cmd

### DIFF
--- a/21-custom-form/setup.cmd
+++ b/21-custom-form/setup.cmd
@@ -12,7 +12,7 @@ set unique_id=!random!!random!
 
 rem Create a storage account in your Azure resource group 
 echo Creating storage...
-call az storage account create --name ai102form!unique_id! --subscription !subscription_id! --resource-group !resource_group! --location !location! --sku Standard_LRS --encryption-services blob --default-action Allow --output none
+call az storage account create --name ai102form!unique_id! --subscription !subscription_id! --resource-group !resource_group! --location !location! --sku Standard_LRS --encryption-services blob --default-action Allow --output none --allow-blob-public-access true
 
 echo Uploading files...
 rem Get storage key to create a container in the storage account 


### PR DESCRIPTION
# Module: 21
## Lab/Demo: setup.cmd

Fixes setup.cmd. Storage account was created without public access, so the corresponding container couldn't be created with public access either and the script fails.

Changes proposed in this pull request:
- Add `--allow-blob-public-access true` to `az storage account create`