### PR TITLE
Added missing parameters to az storage account create

### DIFF
--- a/23-custom-search-skill/setup.cmd
+++ b/23-custom-search-skill/setup.cmd
@@ -10,7 +10,7 @@ rem Get random numbers to create unique resource names
 set unique_id=!random!!random!
 
 echo Creating storage...
-call az storage account create --name ai102str!unique_id! --subscription !subscription_id! --resource-group !resource_group! --location !location! --sku Standard_LRS --encryption-services blob --default-action Allow --output none --allow-blob-public-access true
+call az storage account create --name ai102str!unique_id! --subscription !subscription_id! --resource-group !resource_group! --location !location! --sku Standard_LRS --encryption-services blob --default-action Allow --allow-blob-public-access true --output none
 
 echo Uploading files...
 rem Hack to get storage key

--- a/23-custom-search-skill/setup.cmd
+++ b/23-custom-search-skill/setup.cmd
@@ -2,9 +2,9 @@
 SETLOCAL ENABLEDELAYEDEXPANSION
 
 rem Set values for your subscription and resource group
-set subscription_id=66749cd0-7c7c-4eee-b8d5-1f7a66e748f8
-set resource_group=rg-ai102
-set location=eastus
+set subscription_id=YOUR_SUBSCRIPTION_ID
+set resource_group=YOUR_RESOURCE_GROUP
+set location=YOUR_LOCATION_NAME
 
 rem Get random numbers to create unique resource names
 set unique_id=!random!!random!

--- a/23-custom-search-skill/setup.cmd
+++ b/23-custom-search-skill/setup.cmd
@@ -2,15 +2,15 @@
 SETLOCAL ENABLEDELAYEDEXPANSION
 
 rem Set values for your subscription and resource group
-set subscription_id=YOUR_SUBSCRIPTION_ID
-set resource_group=YOUR_RESOURCE_GROUP
-set location=YOUR_LOCATION_NAME
+set subscription_id=66749cd0-7c7c-4eee-b8d5-1f7a66e748f8
+set resource_group=rg-ai102
+set location=eastus
 
 rem Get random numbers to create unique resource names
 set unique_id=!random!!random!
 
 echo Creating storage...
-call az storage account create --name ai102str!unique_id! --subscription !subscription_id! --resource-group !resource_group! --location !location! --sku Standard_LRS --encryption-services blob --default-action Allow --output none
+call az storage account create --name ai102str!unique_id! --subscription !subscription_id! --resource-group !resource_group! --location !location! --sku Standard_LRS --encryption-services blob --default-action Allow --output none --allow-blob-public-access true
 
 echo Uploading files...
 rem Hack to get storage key

--- a/24-knowledge-store/setup.cmd
+++ b/24-knowledge-store/setup.cmd
@@ -10,7 +10,7 @@ rem Get random numbers to create unique resource names
 set unique_id=!random!!random!
 
 echo Creating storage...
-call az storage account create --name ai102str!unique_id! --subscription !subscription_id! --resource-group !resource_group! --location !location! --sku Standard_LRS --encryption-services blob --default-action Allow --output none
+call az storage account create --name ai102str!unique_id! --subscription !subscription_id! --resource-group !resource_group! --location !location! --sku Standard_LRS --encryption-services blob --default-action Allow --allow-blob-public-access true --output none
 
 echo Uploading files...
 rem Hack to get storage key


### PR DESCRIPTION
# Module: 23, 24
## Lab/Demo: setup.cmd

Changes proposed in this pull request:
Because of recent Azure CLI updates, the storage account gets created without blob public access, however the steps require public access.