### PR TITLE
Update 04-containers/rest-test.cmd

### DIFF
--- a/04-containers/rest-test.cmd
+++ b/04-containers/rest-test.cmd
@@ -1,1 +1,1 @@
-curl POST "http://<your_ACI_IP_address_or_FQDN>:5000/text/analytics/v3.0/languages" -H "Content-Type: application/json" --data-ascii "{'documents':[{'id':1,'text':'Hello world.'},{'id':2,'text':'Salut tout le monde.'}]}"
+curl -X POST "http://<your_ACI_IP_address_or_FQDN>:5000/text/analytics/v3.0/languages" -H "Content-Type: application/json" --data-ascii "{'documents':[{'id':1,'text':'Hello world.'},{'id':2,'text':'Salut tout le monde.'}]}"


### PR DESCRIPTION
The existing curl command is missing the http method argument '-X'.

This causes the error:
"curl: (6) Could not resolve host: POST"

# Module: [AI-102-AIEngineer](https://github.com/MicrosoftLearning/AI-102-AIEngineer/)
## Lab/Demo: 04-containers

Fixes # .

Changes proposed in this pull request:

Add the http method -X argument to the curl command in the rest-test.cmd file.
-
-
-